### PR TITLE
Add global watch flag and implement in track command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,6 +14,7 @@ var (
 	// Used for flags.
 	cfgFile     string
 	userLicense string
+	watch       bool
 
 	rootCmd = &cobra.Command{
 		Use:   "crypto",
@@ -29,10 +30,10 @@ func Execute() error {
 func init() {
 	cobra.OnInitialize(initConfig)
 
+	rootCmd.PersistentFlags().BoolVarP(&watch, "watch", "w", false, "continously loop over command")
 	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.cobra.yaml)")
 	// rootCmd.PersistentFlags().StringP("author", "a", "YOUR NAME", "author name for copyright attribution")
 	// rootCmd.PersistentFlags().StringVarP(&userLicense, "license", "l", "", "name of license for the project")
-	// rootCmd.PersistentFlags().Bool("viper", true, "use Viper for configuration")
 	// viper.BindPFlag("author", rootCmd.PersistentFlags().Lookup("author"))
 	// viper.BindPFlag("useViper", rootCmd.PersistentFlags().Lookup("viper"))
 	// viper.SetDefault("author", "NAME HERE <EMAIL ADDRESS>")

--- a/cmd/track.go
+++ b/cmd/track.go
@@ -43,13 +43,10 @@ var trackCmd = &cobra.Command{
 	Short: "Allows you to track the rise and fall of specific coins",
 
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// maybe? https://stackoverflow.com/questions/16466320/is-there-a-way-to-do-repetitive-tasks-at-intervals
 		if watch {
-			m, err := doEvery(20*time.Millisecond, execute())
-			if !err != nil {
-				return err
-			}
-			fmt.Print(m)
+			doEvery(2000*time.Millisecond, loop)
+		} else {
+			execute()
 		}
 		return nil
 	},
@@ -61,16 +58,21 @@ func doEvery(d time.Duration, f func(time.Time)) {
 	}
 }
 
-func execute() (string, error) {
+func loop(t time.Time) {
+	execute()
+}
+
+func execute() {
+	var s string
 	m, err := createMap()
 	if err != nil {
-		return "", err
+		fmt.Println(err)
 	}
 
 	for k, v := range m {
-		return fmt.Print(strings.ToUpper(k) + " " + v), err
+		s = s + strings.ToUpper(k) + " " + v
 	}
-	return "", nil
+	fmt.Println(s)
 }
 
 func createMap() (map[string]string, error) {


### PR DESCRIPTION
This required me to build a key value pair of the coin and its price, then I built the string to display track. Finally, if the user specifies `--watch=true` or `-w=true` then the command will continuously loop until a ctrl+c is issued.

You can now run `crypto track --coin btc --watch=true` for a continuous loop.